### PR TITLE
Fix mongodb volume path to make it persistent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,7 +168,7 @@ services:
     networks:
       - default
     volumes:
-      - mongo-db:/data
+      - mongo-db:/data/db
     healthcheck:
       test: |
         host=`hostname --ip-address || echo '127.0.0.1'`; 


### PR DESCRIPTION
This might need to be fixed in other tutorial files as well.
The currently configured mongodb volume is not persistent, because the wrong path is used 
https://stackoverflow.com/a/61132140/3450689 